### PR TITLE
Add environmental variables for pipeline orchestration.

### DIFF
--- a/collector/app.py
+++ b/collector/app.py
@@ -1,3 +1,4 @@
+import os
 import json
 import time
 import utils

--- a/collector/app.py
+++ b/collector/app.py
@@ -8,6 +8,8 @@ logging.basicConfig(format='%(levelname)s %(asctime)s %(filename)s %(lineno)d: %
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+CONSUME = os.getenv('CONSUME')
+
 
 def callback(ch, method, properties, body):
     data = json.loads(body)
@@ -37,8 +39,7 @@ def main():
     time.sleep(30)
     logger.info('... done ...')
 
-    consume = 'actors'
-    rabbit_consume = utils.RabbitClient(queue=consume,
+    rabbit_consume = utils.RabbitClient(queue=CONSUME,
                                         host='rabbitmq')
 
     rabbit_consume.receive(callback)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,23 +14,23 @@ services:
       - PUBLISH=ingest
     networks:
       - miner
-  mitie:
-    image: mitie
-    build: ./mitie
-    depends_on:
-      - rabbitmq
-    environment:
-      - CONSUME=ingest
-      - PUBLISH=mitie
-    networks:
-      - miner
+#  mitie:
+#    image: mitie
+#    build: ./mitie
+#    depends_on:
+#      - rabbitmq
+#    environment:
+#      - CONSUME=ingest
+#      - PUBLISH=mitie
+#    networks:
+#      - miner
   predpatt:
     image: predpatt 
     build: ./predpatt
     depends_on:
       - rabbitmq
     environment:
-      - CONSUME=mitie
+      - CONSUME=ingest
       - PUBLISH=predpatt
     networks:
       - miner

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,16 +14,16 @@ services:
       - PUBLISH=ingest
     networks:
       - miner
-#  mitie:
-#    image: mitie
-#    build: ./mitie
-#    depends_on:
-#      - rabbitmq
-#    environment:
-#      - CONSUME=ingest
-#      - PUBLISH=mitie
-#    networks:
-#      - miner
+  mitie:
+    image: mitie
+    build: ./mitie
+    depends_on:
+      - rabbitmq
+    environment:
+      - CONSUME=ingest
+      - PUBLISH=mitie
+    networks:
+      - miner
   predpatt:
     image: predpatt 
     build: ./predpatt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - rabbitmq
     ports:
       - "6000:6000"
+    environment:
+      - PUBLISH=ingest
     networks:
       - miner
   mitie:
@@ -17,6 +19,9 @@ services:
     build: ./mitie
     depends_on:
       - rabbitmq
+    environment:
+      - CONSUME=ingest
+      - PUBLISH=mitie
     networks:
       - miner
   predpatt:
@@ -24,6 +29,9 @@ services:
     build: ./predpatt
     depends_on:
       - rabbitmq
+    environment:
+      - CONSUME=mitie
+      - PUBLISH=predpatt
     networks:
       - miner
   relevancy:
@@ -31,6 +39,9 @@ services:
     build: ./relevancy
     depends_on:
       - rabbitmq
+    environment:
+      - CONSUME=predpatt
+      - PUBLISH=relevancy
     networks:
       - miner
   quad:
@@ -38,6 +49,9 @@ services:
     build: ./quad
     depends_on:
       - rabbitmq
+    environment:
+      - CONSUME=relevancy
+      - PUBLISH=quad
     networks:
       - miner
   collector:
@@ -45,6 +59,8 @@ services:
     build: ./collector
     depends_on:
       - rabbitmq
+    environment:
+      - CONSUME=actors
     networks:
       - miner
     volumes:

--- a/hypnos/app.py
+++ b/hypnos/app.py
@@ -64,7 +64,7 @@ def extract(message):
             logger.info('Something went wrong in the formatting. {}\n'.format(e))
             pass
 
-    rabbit_publish.send(story, publish)
+    rabbit_publish.send(story, PUBLISH)
 
 
 def send_to_petr(event_dict):

--- a/hypnos/app.py
+++ b/hypnos/app.py
@@ -37,7 +37,7 @@ def extract(message):
     #keys = [k for k in keys if k != 'predicted_relevancy']
     for val in keys:
         logger.info('Processing {}'.format(val))
-        text = story['event_info'][val]['sent']
+        text = story['event_info'][val]['sent']['text']
         text = text.encode('utf-8')
 
         event_dict = send_to_corenlp(story, text)

--- a/hypnos/app.py
+++ b/hypnos/app.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 cwd = os.path.abspath(os.path.dirname(__file__))
+CONSUME = os.getenv('CONSUME')
+PUBLISH = os.getenv('PUBLISH')
 
 
 def callback(ch, method, properties, body):
@@ -26,8 +28,7 @@ def callback(ch, method, properties, body):
 
 
 def extract(message):
-    publish = 'actors'
-    rabbit_publish = utils.RabbitClient(queue=publish,
+    rabbit_publish = utils.RabbitClient(queue=PUBLISH,
                                         host='rabbitmq')
 
     story = message
@@ -130,8 +131,7 @@ def main():
     time.sleep(60)
     logger.info('... done ...')
 
-    consume = 'quad'
-    rabbit_consume = utils.RabbitClient(queue=consume,
+    rabbit_consume = utils.RabbitClient(queue=CONSUME,
                                         host='rabbitmq')
 
     rabbit_consume.receive(callback)

--- a/hypnos/docker-compose.yml
+++ b/hypnos/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     build: .
     ports:
         - "5002:5002"
+    environment:
+      - CONSUME=quad
+      - PUBLISH=actors
     networks:
         - eventminer_miner
   ccnlp:

--- a/miner/app.py
+++ b/miner/app.py
@@ -51,7 +51,7 @@ class MinerAPI(Resource):
         data['pipeline_key'] = pipeline_key
 
         logger.info('Sending to the downstream...')
-        rabbit.send(data, message_route)
+        rabbit.send(data, PUBLISH)
 
         logging.info('Sent {}'.format(pipeline_key))
         return pipeline_key

--- a/miner/app.py
+++ b/miner/app.py
@@ -50,7 +50,7 @@ class MinerAPI(Resource):
         pipeline_key = str(uuid.uuid4())
         data['pipeline_key'] = pipeline_key
 
-        logger.info('Sending to the downstream...')
+        logger.info('Sending to the downstream with key {}...'.format(pipeline_key))
         rabbit.send(data, PUBLISH)
 
         logging.info('Sent {}'.format(pipeline_key))

--- a/miner/app.py
+++ b/miner/app.py
@@ -20,6 +20,8 @@ api = Api(app)
 
 cwd = os.path.abspath(os.path.dirname(__file__))
 
+PUBLISH = os.getenv('PUBLISH')
+
 
 @app.errorhandler(400)
 def bad_request(error):
@@ -39,9 +41,8 @@ class MinerAPI(Resource):
 
     def post(self):
         args = self.reqparse.parse_args()
-        message_route = 'ingest'
 
-        rabbit = utils.RabbitClient(queue=message_route, host='rabbitmq')
+        rabbit = utils.RabbitClient(queue=PUBLISH, host='rabbitmq')
 
         logger.info('Received data...')
         data = args['data']

--- a/mitie/app.py
+++ b/mitie/app.py
@@ -33,7 +33,8 @@ def process(data):
     data['ner_info'] = {}
     for sid, sent in data['sents'].iteritems():
         try:
-            tokens = tokenize(sent)
+            print(sent)
+            tokens = tokenize(sent['text'])
             entities = NER.extract_entities(tokens)
 
             new_ents = []

--- a/mitie/app.py
+++ b/mitie/app.py
@@ -1,3 +1,4 @@
+import os
 import json
 import time
 import utils
@@ -12,6 +13,9 @@ logger.setLevel(logging.INFO)
 
 NER = named_entity_extractor('MITIE-models/english/ner_model.dat')
 
+CONSUME = os.getenv('CONSUME')
+PUBLISH = os.getenv('PUBLISH')
+
 
 def callback(ch, method, properties, body):
     data = json.loads(body)
@@ -24,8 +28,7 @@ def callback(ch, method, properties, body):
 
 
 def process(data):
-    publish = 'mitie'
-    rabbit_publish = utils.RabbitClient(queue=publish,
+    rabbit_publish = utils.RabbitClient(queue=PUBLISH,
                                         host='rabbitmq')
     data['ner_info'] = {}
     for sid, sent in data['sents'].iteritems():
@@ -58,8 +61,7 @@ def main():
     time.sleep(30)
     logger.info('... done ...')
 
-    consume = 'ingest'
-    rabbit_consume = utils.RabbitClient(queue=consume,
+    rabbit_consume = utils.RabbitClient(queue=CONSUME,
                                         host='rabbitmq')
 
     rabbit_consume.receive(callback)

--- a/mitie/app.py
+++ b/mitie/app.py
@@ -53,7 +53,7 @@ def process(data):
 
     logger.info('Finished processing content.')
 
-    rabbit_publish.send(data, publish)
+    rabbit_publish.send(data, PUBLISH)
 
 
 def main():

--- a/predpatt/app.py
+++ b/predpatt/app.py
@@ -1,3 +1,4 @@
+import os
 import json
 import time
 import utils
@@ -11,6 +12,10 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
 
+CONSUME = os.getenv('CONSUME')
+PUBLISH = os.getenv('PUBLISH')
+
+
 def callback(ch, method, properties, body):
     data = json.loads(body)
     logger.info('Started processing content. {}'.format(data['pipeline_key']))
@@ -22,8 +27,7 @@ def callback(ch, method, properties, body):
 
 
 def process(data):
-    publish = 'predpatt'
-    rabbit_publish = utils.RabbitClient(queue=publish,
+    rabbit_publish = utils.RabbitClient(queue=PUBLISH,
                                         host='rabbitmq')
     data['predicate_info'] = {}
     for sid, sent in data['sents'].iteritems():
@@ -46,8 +50,7 @@ def main():
     time.sleep(30)
     logger.info('... done ...')
 
-    consume = 'mitie'
-    rabbit_consume = utils.RabbitClient(queue=consume,
+    rabbit_consume = utils.RabbitClient(queue=CONSUME,
                                         host='rabbitmq')
 
     rabbit_consume.receive(callback)

--- a/predpatt/app.py
+++ b/predpatt/app.py
@@ -42,7 +42,7 @@ def process(data):
 
     logger.info('Finished processing content.')
 
-    rabbit_publish.send(data, publish)
+    rabbit_publish.send(data, PUBLISH)
 
 
 def main():

--- a/predpatt/app.py
+++ b/predpatt/app.py
@@ -32,7 +32,7 @@ def process(data):
     data['predicate_info'] = {}
     for sid, sent in data['sents'].iteritems():
         try:
-            output = ParseyPredFace.parse(sent)
+            output = ParseyPredFace.parse(sent['text'])
 
             data['predicate_info'][sid] = output
         except Exception as e:

--- a/quad/app.py
+++ b/quad/app.py
@@ -39,7 +39,7 @@ def process(data, model, vocab, vocab_size, check):
         try:
             logger.info('Processing sent {} for content {}'.format(sid,
                                                                    data['pipeline_key']))
-            mat = utils.encode_data([sent], MAXLEN, vocab, vocab_size, check)
+            mat = utils.encode_data([sent['text']], MAXLEN, vocab, vocab_size, check)
             pred = model.predict(mat)
             pred_class = pred.argmax(1)[0]
             pred_score = pred[0][pred_class]
@@ -51,6 +51,7 @@ def process(data, model, vocab, vocab_size, check):
             # If something goes wrong, log it and return nothing
             logger.info(e)
             # Make sure to update this line if you change the variable names
+            data['event_info'][sid] = {}
             data['event_info'][sid]['predicted_class'] = {}
 
     rabbit_publish.send(data, PUBLISH)

--- a/quad/app.py
+++ b/quad/app.py
@@ -1,3 +1,4 @@
+import os
 import json
 import time
 import utils

--- a/quad/app.py
+++ b/quad/app.py
@@ -9,6 +9,8 @@ logger.setLevel(logging.INFO)
 
 
 MAXLEN = 1400
+CONSUME = os.getenv('CONSUME')
+PUBLISH = os.getenv('PUBLISH')
 
 
 def callback(ch, method, properties, body):
@@ -27,8 +29,7 @@ def callback(ch, method, properties, body):
 
 
 def process(data, model, vocab, vocab_size, check):
-    publish = 'quad'
-    rabbit_publish = utils.RabbitClient(queue=publish,
+    rabbit_publish = utils.RabbitClient(queue=PUBLISH,
                                         host='rabbitmq')
 
     sents = data['sents']
@@ -59,8 +60,7 @@ def main():
     time.sleep(30)
     logger.info('... done ...')
 
-    consume = 'relevancy'
-    rabbit_consume = utils.RabbitClient(queue=consume,
+    rabbit_consume = utils.RabbitClient(queue=CONSUME,
                                         host='rabbitmq')
 
     rabbit_consume.receive(callback)

--- a/quad/app.py
+++ b/quad/app.py
@@ -53,7 +53,7 @@ def process(data, model, vocab, vocab_size, check):
             # Make sure to update this line if you change the variable names
             data['event_info'][sid]['predicted_class'] = {}
 
-    rabbit_publish.send(data, publish)
+    rabbit_publish.send(data, PUBLISH)
 
 
 def main():

--- a/quad/launch.sh
+++ b/quad/launch.sh
@@ -1,11 +1,5 @@
 set -x
-#echo "Decompressing models..."
-#cd $MESOS_SANDBOX
-#tar xzf $CLF_FILE
-#rm -rf $CLF_FILE
-#cd /
-set -x
-echo "Starting up Kafka analytic service..."
+echo "Starting up analytic service..."
 python /src/app.py -m /src/quad_trained/quad_character_model.json \
                    -w /src/quad_trained/quad_character_model_weights.h5 \
                    -v /src/quad_trained/quad_character_model_vocab.pkl

--- a/relevancy/app.py
+++ b/relevancy/app.py
@@ -1,3 +1,4 @@
+import os
 import json
 import time
 import utils

--- a/relevancy/app.py
+++ b/relevancy/app.py
@@ -36,7 +36,7 @@ def process(data, tfidf, clf):
         logger.info(e)
         # Make sure to update this line if you change the variable names
 
-    rabbit_publish.send(data, publish)
+    rabbit_publish.send(data, PUBLISH)
 
 
 def main():

--- a/relevancy/app.py
+++ b/relevancy/app.py
@@ -7,6 +7,9 @@ logging.basicConfig(format='%(levelname)s %(asctime)s %(filename)s %(lineno)d: %
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
+CONSUME = os.getenv('CONSUME')
+PUBLISH = os.getenv('PUBLISH')
+
 
 def callback(ch, method, properties, body):
     global TFIDF, CLF
@@ -20,8 +23,7 @@ def callback(ch, method, properties, body):
 
 
 def process(data, tfidf, clf):
-    publish = 'relevancy'
-    rabbit_publish = utils.RabbitClient(queue=publish,
+    rabbit_publish = utils.RabbitClient(queue=PUBLISH,
                                         host='rabbitmq')
     try:
         mat = tfidf.transform([data['title']])
@@ -41,8 +43,7 @@ def main():
     time.sleep(30)
     logger.info('... done ...')
 
-    consume = 'predpatt'
-    rabbit_consume = utils.RabbitClient(queue=consume,
+    rabbit_consume = utils.RabbitClient(queue=CONSUME,
                                         host='rabbitmq')
 
     rabbit_consume.receive(callback)


### PR DESCRIPTION
Previously each analytic had the RabbitMQ queue information hard coded. This PR changes this so that each analytic instead pulls queue information from environmental variables set in the `docker-compose.yml` file. This has two main advantages:

1) Containers can be arbitrarily reordered with less programming overhead. A change is two lines in a central location rather than 3+ across application code.
2) Containers don't need to rebuilt to change processing logic.