### PR TITLE
Pass outputs from MITIE to PredPatt

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     depends_on:
       - rabbitmq
     environment:
-      - CONSUME=ingest
+      - CONSUME=mitie
       - PUBLISH=predpatt
     networks:
       - miner


### PR DESCRIPTION
Without this change, MITIE and PredPatt both consume messages from `ingest` and the output from MITIE goes into a black hole.