### PR TITLE
Put the output for each article into its own file

### DIFF
--- a/collector/app.py
+++ b/collector/app.py
@@ -24,14 +24,24 @@ def callback(ch, method, properties, body):
 
 
 def process(data):
+    key = '<unknown>'
     try:
-        now = datetime.datetime.utcnow().strftime('%Y%m%d')
-        filename = '/src/data/events.{}.txt'.format(now)
-        with open(filename, 'a+') as f:
-            f.write(json.dumps(data) + '\n')
-    except Exception as e:
+        key = data['pipeline_key']
+        logger.info('Got results for {}'.format(key))
+
+        root = '/src/data/'
+        now = datetime.datetime.utcnow().strftime('%Y/%m/%d')
+        path = os.path.join(root, now)
+
+        if not os.path.exists(path):
+            os.makedirs(path)
+
+        fname = '{}.json'.format(key)
+        with open(os.path.join(path, fname), 'w') as f:
+            f.write(json.dumps(data))
+    except:
         # If something goes wrong, log it and return nothing
-        logger.info(e)
+        logger.exception('Failed to write results for {}'.format(key))
         # Make sure to update this line if you change the variable names
 
 


### PR DESCRIPTION
Rather than creating one file per day, we create a `YYYY/MM/DD` directory
hierarchy and place a `<pipeline_id>.json` file in there. This makes it
relatively easy to verify that an article has passed all the way through
the pipeline.