### PR TITLE
Use `wait-for` instead of `time.sleep` to ensure service availability

### DIFF
--- a/collector/Dockerfile
+++ b/collector/Dockerfile
@@ -10,4 +10,4 @@ ADD . /src
 
 RUN cd /src; pip install -r requirements.txt
 
-CMD ["python", "/src/app.py"]
+CMD ["/src/wait-for", "rabbitmq:5672", "--", "python", "/src/app.py"]

--- a/collector/app.py
+++ b/collector/app.py
@@ -1,6 +1,5 @@
 import os
 import json
-import time
 import utils
 import logging
 import datetime
@@ -36,13 +35,7 @@ def process(data):
 
 
 def main():
-    logger.info('... waiting ...')
-    time.sleep(30)
-    logger.info('... done ...')
-
-    rabbit_consume = utils.RabbitClient(queue=CONSUME,
-                                        host='rabbitmq')
-
+    rabbit_consume = utils.RabbitClient(queue=CONSUME, host='rabbitmq')
     rabbit_consume.receive(callback)
 
 

--- a/collector/wait-for
+++ b/collector/wait-for
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+    
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"

--- a/hypnos/Dockerfile
+++ b/hypnos/Dockerfile
@@ -8,4 +8,4 @@ ADD . /src
 
 RUN cd /src; pip install -r requirements.txt
 
-CMD ["/src/wait-for", "ccnlp:5000", "petrarch:5001", "rabbitmq:5672", "-t", "60", "--", "python", "/src/app.py"]
+CMD ["/src/wait-for", "ccnlp:5000", "-t", "60", "--", "python", "/src/app.py"]

--- a/hypnos/Dockerfile
+++ b/hypnos/Dockerfile
@@ -8,4 +8,4 @@ ADD . /src
 
 RUN cd /src; pip install -r requirements.txt
 
-CMD ["python", "/src/app.py"]
+CMD ["/src/wait-for", "ccnlp:5000", "petrarch:5001", "rabbitmq:5672", "-t", "60", "--", "python", "/src/app.py"]

--- a/hypnos/app.py
+++ b/hypnos/app.py
@@ -1,5 +1,4 @@
 import os
-import time
 import json
 import utils
 import logging
@@ -127,13 +126,7 @@ def process_results(event_dict):
 
 
 def main():
-    logger.info('... waiting ...')
-    time.sleep(60)
-    logger.info('... done ...')
-
-    rabbit_consume = utils.RabbitClient(queue=CONSUME,
-                                        host='rabbitmq')
-
+    rabbit_consume = utils.RabbitClient(queue=CONSUME, host='rabbitmq')
     rabbit_consume.receive(callback)
 
 

--- a/hypnos/docker-compose.yml
+++ b/hypnos/docker-compose.yml
@@ -6,8 +6,6 @@ services:
   hypnos:
     image: hypnos
     build: .
-    ports:
-        - "5002:5002"
     environment:
       - CONSUME=quad
       - PUBLISH=actors

--- a/hypnos/wait-for
+++ b/hypnos/wait-for
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+    
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"

--- a/miner/Dockerfile
+++ b/miner/Dockerfile
@@ -18,4 +18,4 @@ RUN cd /src; pip install -r requirements.txt
 
 EXPOSE 6000
 
-CMD ["python", "/src/app.py"]
+CMD ["/src/wait-for", "rabbitmq:5672", "-t", "90", "--", "python", "/src/app.py"]

--- a/miner/wait-for
+++ b/miner/wait-for
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+    
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"

--- a/mitie/Dockerfile
+++ b/mitie/Dockerfile
@@ -16,4 +16,4 @@ RUN pip install -r requirements.txt
 
 EXPOSE 6000
 
-CMD ["python", "/src/app.py"]
+CMD ["/src/wait-for", "rabbitmq:5672", "--", "python", "/src/app.py"]

--- a/mitie/app.py
+++ b/mitie/app.py
@@ -1,6 +1,5 @@
 import os
 import json
-import time
 import utils
 import logging
 
@@ -58,13 +57,7 @@ def process(data):
 
 
 def main():
-    logger.info('... waiting ...')
-    time.sleep(30)
-    logger.info('... done ...')
-
-    rabbit_consume = utils.RabbitClient(queue=CONSUME,
-                                        host='rabbitmq')
-
+    rabbit_consume = utils.RabbitClient(queue=CONSUME, host='rabbitmq')
     rabbit_consume.receive(callback)
 
 

--- a/mitie/wait-for
+++ b/mitie/wait-for
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+    
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"

--- a/predpatt/Dockerfile
+++ b/predpatt/Dockerfile
@@ -1,10 +1,13 @@
 FROM tensorflow/syntaxnet
 #If they ever update this image things will likely break
 
+RUN apt-get install -y netcat
+
 #y_tho.gif
 ENV PYTHONPATH="${PYTHONPATH}:/opt/tensorflow/syntaxnet/bazel-bin/dragnn/tools/oss_notebook_launcher.runfiles/__main__:/opt/tensorflow/syntaxnet/bazel-bin/dragnn/tools/oss_notebook_launcher.runfiles/org_tensorflow"
 
+RUN mkdir /src
 ADD . /src
 RUN pip install -r /src/requirements.txt
 
-CMD ["python", "/src/app.py"]
+CMD ["/src/wait-for", "rabbitmq:5672", "-t", "30", "--", "python", "/src/app.py"]

--- a/predpatt/app.py
+++ b/predpatt/app.py
@@ -1,6 +1,5 @@
 import os
 import json
-import time
 import utils
 import logging
 
@@ -46,13 +45,7 @@ def process(data):
 
 
 def main():
-    logger.info('... waiting ...')
-    time.sleep(30)
-    logger.info('... done ...')
-
-    rabbit_consume = utils.RabbitClient(queue=CONSUME,
-                                        host='rabbitmq')
-
+    rabbit_consume = utils.RabbitClient(queue=CONSUME, host='rabbitmq')
     rabbit_consume.receive(callback)
 
 

--- a/predpatt/wait-for
+++ b/predpatt/wait-for
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+    
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"

--- a/quad/Dockerfile
+++ b/quad/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER John Beieler <jbeieler1@jhu.edu>
 
 #RUN sed -i "s/httpredir.debian.org/`curl -s -D -http://httpredir.debian.org/demo/debian/ | awk '/^Link:/ { print $2 }' | sed -e 's@<http://\(.*\)/debian/>;@\1@g'`/" /etc/apt/sources.list
 RUN apt-get clean && apt-get update
-RUN apt-get install -y build-essential python-dev
+RUN apt-get install -y build-essential python-dev netcat
 
 ADD . /src
 RUN cd /src; pip install -r requirements.txt

--- a/quad/app.py
+++ b/quad/app.py
@@ -1,6 +1,5 @@
 import os
 import json
-import time
 import utils
 import logging
 
@@ -58,13 +57,7 @@ def process(data, model, vocab, vocab_size, check):
 
 
 def main():
-    logger.info('... waiting ...')
-    time.sleep(30)
-    logger.info('... done ...')
-
-    rabbit_consume = utils.RabbitClient(queue=CONSUME,
-                                        host='rabbitmq')
-
+    rabbit_consume = utils.RabbitClient(queue=CONSUME, host='rabbitmq')
     rabbit_consume.receive(callback)
 
 

--- a/quad/launch.sh
+++ b/quad/launch.sh
@@ -1,5 +1,6 @@
 set -x
 echo "Starting up analytic service..."
-python /src/app.py -m /src/quad_trained/quad_character_model.json \
-                   -w /src/quad_trained/quad_character_model_weights.h5 \
-                   -v /src/quad_trained/quad_character_model_vocab.pkl
+./src/wait-for rabbitmq:5672 -t 60 -- python /src/app.py \
+    -m /src/quad_trained/quad_character_model.json \
+    -w /src/quad_trained/quad_character_model_weights.h5 \
+    -v /src/quad_trained/quad_character_model_vocab.pkl

--- a/quad/wait-for
+++ b/quad/wait-for
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+    
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"

--- a/relevancy/Dockerfile
+++ b/relevancy/Dockerfile
@@ -2,7 +2,7 @@ FROM continuumio/anaconda
 
 MAINTAINER John Beieler <jbeieler1@jhu.edu>
 
-RUN apt-get install -y unzip
+RUN apt-get install -y unzip netcat
 
 ADD . /src
 

--- a/relevancy/app.py
+++ b/relevancy/app.py
@@ -1,6 +1,5 @@
 import os
 import json
-import time
 import utils
 import logging
 
@@ -40,13 +39,7 @@ def process(data, tfidf, clf):
 
 
 def main():
-    logger.info('... waiting ...')
-    time.sleep(30)
-    logger.info('... done ...')
-
-    rabbit_consume = utils.RabbitClient(queue=CONSUME,
-                                        host='rabbitmq')
-
+    rabbit_consume = utils.RabbitClient(queue=CONSUME, host='rabbitmq')
     rabbit_consume.receive(callback)
 
 

--- a/relevancy/launch.sh
+++ b/relevancy/launch.sh
@@ -1,5 +1,5 @@
 set -x
 echo "Starting up analytic service..."
 cd /src
-python /src/app.py -m /src/relevancy_trained_classifier/svm/relevancy_classifier.pkl \
+./wait-for rabbitmq:5672 -t 60 -- python /src/app.py -m /src/relevancy_trained_classifier/svm/relevancy_classifier.pkl \
                    -tf /src/relevancy_trained_classifier/tfidf/relevancy_classifier_tfidf.pkl

--- a/relevancy/wait-for
+++ b/relevancy/wait-for
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+    
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"


### PR DESCRIPTION
Essentially, each app defines which network services it depends on (mostly just rabbitmq) by passing parameters to `wait-for`. I think I've mapped them all out accurately; some timeouts may need tweaking depending on how quick containers spin up.